### PR TITLE
13 rest api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'bootsnap', require: false
 gem 'cancancan'
 gem 'cocoon'
 gem 'devise'
+gem 'doorkeeper'
 gem 'jbuilder'
 gem 'omniauth'
 gem 'omniauth-facebook'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby '3.2.2'
 
+gem 'active_model_serializers'
 gem 'aws-sdk-s3', require: false
 gem 'bootsnap', require: false
 gem 'cancancan'
@@ -9,6 +10,7 @@ gem 'cocoon'
 gem 'devise'
 gem 'doorkeeper'
 gem 'jbuilder'
+gem 'oj'
 gem 'omniauth'
 gem 'omniauth-facebook'
 gem 'omniauth-github'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,11 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_model_serializers (0.10.15)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (7.1.5.1)
       activesupport (= 7.1.5.1)
       globalid (>= 0.3.6)
@@ -119,6 +124,8 @@ GEM
     capybara-email (3.0.2)
       capybara (>= 2.4, < 4.0)
       mail
+    case_transform (0.2)
+      activesupport
     childprocess (5.1.0)
       logger (~> 1.5)
     cocoon (1.2.15)
@@ -169,6 +176,7 @@ GEM
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
     json (2.9.1)
+    jsonapi-renderer (0.2.2)
     jwt (2.10.1)
       base64
     language_server-protocol (3.17.0.3)
@@ -219,6 +227,9 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0, >= 2.0.3)
       version_gem (>= 1.1.8, < 3)
+    oj (3.16.11)
+      bigdecimal (>= 3.0)
+      ostruct (>= 0.2)
     omniauth (2.1.3)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -236,6 +247,7 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
+    ostruct (0.6.2)
     package_json (0.1.0)
     parallel (1.26.3)
     parser (3.3.7.0)
@@ -423,6 +435,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_serializers
   aws-sdk-s3
   bootsnap
   cancancan
@@ -437,6 +450,7 @@ DEPENDENCIES
   jbuilder
   launchy
   letter_opener
+  oj
   omniauth
   omniauth-facebook
   omniauth-github

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.1)
+    doorkeeper (5.8.2)
+      railties (>= 5)
     drb (2.2.1)
     erubi (1.13.1)
     factory_bot (6.5.0)
@@ -430,6 +432,7 @@ DEPENDENCIES
   database_cleaner-active_record (~> 2.0)
   debug
   devise
+  doorkeeper
   factory_bot_rails
   jbuilder
   launchy

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,5 @@
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
+//= link doorkeeper/admin/application.css
+//= link doorkeeper/application.css

--- a/app/controllers/api/v1/answers_controller.rb
+++ b/app/controllers/api/v1/answers_controller.rb
@@ -1,0 +1,60 @@
+class Api::V1::AnswersController < Api::V1::BaseController
+  before_action :find_question, only: %i[index create]
+  before_action :find_answer, only: %i[show update destroy]
+
+  authorize_resource
+
+  def index
+    @answers = @question.answers
+    render json: @answers
+  end
+
+  def show
+    render json: @answer
+  end
+
+  def create
+    @answer = @question.answers.build(answer_params.merge(author_id: current_resource_owner.id))
+
+    if @answer.save
+      render json: { answer: @answer }, status: :created
+    else
+      render json: { errors: @answer.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH /api/v1/answers/:id
+  def update
+    if @answer.update(answer_params)
+      render json: { answer: @answer }, status: :ok
+    else
+      render json: { errors: @answer.errors.full_messages },
+             status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /api/v1/answers/:id
+  def destroy
+    payload = ActiveModelSerializers::SerializableResource.new(@answer).as_json
+    @answer.destroy
+    render json: payload, status: :ok
+  end
+
+  private
+
+  def find_question
+    @question = Question.find(params[:question_id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { errors: ['Question not found'] }, status: :not_found
+  end
+
+  def find_answer
+    @answer = Answer.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { errors: ['Answer not found'] }, status: :not_found
+  end
+
+  def answer_params
+    params.require(:answer).permit(:body)
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::BaseController < ApplicationController
+  before_action :doorkeeper_authorize!
+
+  private
+
+  def current_resource_owner
+    @current_resource_owner ||= User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,6 +1,16 @@
 class Api::V1::BaseController < ApplicationController
   before_action :doorkeeper_authorize!
 
+  include CanCan::ControllerAdditions
+
+  def current_user
+    current_resource_owner
+  end
+
+  rescue_from CanCan::AccessDenied do |exception|
+    render json: { error: exception.message }, status: :forbidden
+  end
+
   private
 
   def current_resource_owner

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::ProfilesController < Api::V1::BaseController
+  def me
+    render json: current_resource_owner
+  end
+end

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,5 +1,11 @@
 class Api::V1::ProfilesController < Api::V1::BaseController
+  authorize_resource class: User
+
   def me
     render json: current_resource_owner
+  end
+
+  def index
+    render json: User.where.not(id: current_resource_owner.id)
   end
 end

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::QuestionsController < Api::V1::BaseController
+  def index
+    @questions = Question.all
+    render json: @questions.to_json(include: :answers)
+  end
+end

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -1,6 +1,52 @@
 class Api::V1::QuestionsController < Api::V1::BaseController
+  before_action :find_question, only: %i[show update destroy]
+
+  authorize_resource
+
   def index
-    @questions = Question.all
-    render json: @questions.to_json(include: :answers)
+    @questions = Question.with_attached_files.all
+    render json: @questions
+  end
+
+  def show
+    render json: @question
+  end
+
+  def create
+    @question = current_resource_owner.questions.build(question_params)
+
+    if @question.save
+      render json: { question: @question }, status: :created
+    else
+      render json: { errors: @question.errors.full_messages },
+             status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @question.update(question_params)
+      render json: { question: @question }, status: :ok
+    else
+      render json: { errors: @question.errors.full_messages },
+             status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    payload = ActiveModelSerializers::SerializableResource.new(@question).as_json
+    @question.destroy
+    render json: payload, status: :ok
+  end
+
+  private
+
+  def find_question
+    @question = Question.with_attached_files.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { errors: ['Question not found'] }, status: :not_found
+  end
+
+  def question_params
+    params.require(:question).permit(:title, :body)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-
   skip_authorization_check if: :skip_cancan_authorization?
   check_authorization unless: :skip_cancan_authorization?
 
@@ -14,10 +13,6 @@ class ApplicationController < ActionController::Base
   private
 
   def skip_cancan_authorization?
-    devise_controller? || api_request?
-  end
-
-  def api_request?
-    request.path.start_with?('/api/')
+    devise_controller?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 class ApplicationController < ActionController::Base
-  # include Pundit
+
+  skip_authorization_check if: :skip_cancan_authorization?
+  check_authorization unless: :skip_cancan_authorization?
 
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|
@@ -9,5 +11,13 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  check_authorization unless: :devise_controller?
+  private
+
+  def skip_cancan_authorization?
+    devise_controller? || api_request?
+  end
+
+  def api_request?
+    request.path.start_with?('/api/')
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,6 +24,7 @@ class Ability
 
   def user_abilities
     guest_abilities
+    can :me, User
     can :create, [Question, Answer, Comment]
     can :update, [Question, Answer], author: user
     can :destroy, [Question, Answer], author: user

--- a/app/serializers/answer_serializer.rb
+++ b/app/serializers/answer_serializer.rb
@@ -1,0 +1,15 @@
+class AnswerSerializer < ActiveModel::Serializer
+  attributes :id, :body, :created_at, :updated_at, :files, :author_id
+
+  has_many :links
+  has_many :comments
+
+  belongs_to :author
+  belongs_to :question
+
+  def files
+    object.files.map do |file|
+      Rails.application.routes.url_helpers.rails_blob_url(file, only_path: false)
+    end
+  end
+end

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -1,0 +1,3 @@
+class CommentSerializer < ActiveModel::Serializer
+  attributes :id, :body, :created_at, :updated_at, :user
+end

--- a/app/serializers/link_serializer.rb
+++ b/app/serializers/link_serializer.rb
@@ -1,0 +1,3 @@
+class LinkSerializer < ActiveModel::Serializer
+  attributes :id, :name, :url
+end

--- a/app/serializers/question_serializer.rb
+++ b/app/serializers/question_serializer.rb
@@ -1,0 +1,19 @@
+class QuestionSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body, :created_at, :updated_at, :short_title, :files
+
+  has_many :answers
+  has_many :links
+  has_many :comments
+
+  belongs_to :author
+
+  def short_title
+    object.title.truncate(7)
+  end
+
+  def files
+    object.files.map do |file|
+      Rails.application.routes.url_helpers.rails_blob_url(file, only_path: false)
+    end
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :created_at, :updated_at, :email, :admin
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -78,4 +78,5 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
   config.action_mailer.default_url_options = { host: 'localhost', port: 3030 }
+  Rails.application.routes.default_url_options = { host: 'localhost', port: 3030 }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,6 +63,7 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+  Rails.application.routes.default_url_options = { host: 'localhost', port: 3030 }
 
   OmniAuth.config.test_mode = true
 end

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,0 +1,2 @@
+ActiveModelSerializers.config.adapter = :json
+Oj.optimize_rails

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -241,7 +241,7 @@ Doorkeeper.configure do
   # For more information go to
   # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
   #
-  default_scopes  :public
+  default_scopes :public
   # optional_scopes :write, :update
 
   # Allows to restrict only certain scopes for grant_type.

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,526 @@
+# frozen_string_literal: true
+
+Doorkeeper.configure do
+  # Change the ORM that doorkeeper will use (requires ORM extensions installed).
+  # Check the list of supported ORMs here: https://github.com/doorkeeper-gem/doorkeeper#orms
+  orm :active_record
+
+  # This block will be called to check whether the resource owner is authenticated or not.
+  resource_owner_authenticator do
+    current_user || warden.authinticate!(scope: :user)
+  end
+
+  # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb
+  # file then you need to declare this block in order to restrict access to the web interface for
+  # adding oauth authorized applications. In other case it will return 403 Forbidden response
+  # every time somebody will try to access the admin web interface.
+  #
+  admin_authenticator do
+    # Put your admin authentication logic here.
+    # Example implementation:
+
+    if current_user
+      head :forbidden unless current_user.admin?
+    else
+      redirect_to new_user_session_path
+    end
+  end
+
+  # You can use your own model classes if you need to extend (or even override) default
+  # Doorkeeper models such as `Application`, `AccessToken` and `AccessGrant.
+  #
+  # By default Doorkeeper ActiveRecord ORM uses its own classes:
+  #
+  # access_token_class "Doorkeeper::AccessToken"
+  # access_grant_class "Doorkeeper::AccessGrant"
+  # application_class "Doorkeeper::Application"
+  #
+  # Don't forget to include Doorkeeper ORM mixins into your custom models:
+  #
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken - for access token
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant - for access grant
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::Application - for application (OAuth2 clients)
+  #
+  # For example:
+  #
+  # access_token_class "MyAccessToken"
+  #
+  # class MyAccessToken < ApplicationRecord
+  #   include ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
+  #
+  #   self.table_name = "hey_i_wanna_my_name"
+  #
+  #   def destroy_me!
+  #     destroy
+  #   end
+  # end
+
+  # Enables polymorphic Resource Owner association for Access Tokens and Access Grants.
+  # By default this option is disabled.
+  #
+  # Make sure you properly setup you database and have all the required columns (run
+  # `bundle exec rails generate doorkeeper:enable_polymorphic_resource_owner` and execute Rails
+  # migrations).
+  #
+  # If this option enabled, Doorkeeper will store not only Resource Owner primary key
+  # value, but also it's type (class name). See "Polymorphic Associations" section of
+  # Rails guides: https://guides.rubyonrails.org/association_basics.html#polymorphic-associations
+  #
+  # [NOTE] If you apply this option on already existing project don't forget to manually
+  # update `resource_owner_type` column in the database and fix migration template as it will
+  # set NOT NULL constraint for Access Grants table.
+  #
+  # use_polymorphic_resource_owner
+
+  # If you are planning to use Doorkeeper in Rails 5 API-only application, then you might
+  # want to use API mode that will skip all the views management and change the way how
+  # Doorkeeper responds to a requests.
+  #
+  # api_only
+
+  # Enforce token request content type to application/x-www-form-urlencoded.
+  # It is not enabled by default to not break prior versions of the gem.
+  #
+  # enforce_content_type
+
+  # Authorization Code expiration time (default: 10 minutes).
+  #
+  authorization_code_expires_in 2.hours
+
+  # Access token expiration time (default: 2 hours).
+  # If you set this to `nil` Doorkeeper will not expire the token and omit expires_in in response.
+  # It is RECOMMENDED to set expiration time explicitly.
+  # Prefer access_token_expires_in 100.years or similar,
+  # which would be functionally equivalent and avoid the risk of unexpected behavior by callers.
+  #
+  access_token_expires_in 24.hours
+
+  # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
+  # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to
+  # +access_token_expires_in+ configuration option value. If you really need to issue a
+  # non-expiring access token (which is not recommended) then you need to return
+  # Float::INFINITY from this block.
+  #
+  # `context` has the following properties available:
+  #
+  #   * `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  #   * `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  #   * `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #   * `resource_owner` - authorized resource owner instance (if present)
+  #
+  # custom_access_token_expires_in do |context|
+  #   context.client.additional_settings.implicit_oauth_expiration
+  # end
+
+  # Use a custom class for generating the access token.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-access-token-generator
+  #
+  # access_token_generator '::Doorkeeper::JWT'
+
+  # The controller +Doorkeeper::ApplicationController+ inherits from.
+  # Defaults to +ActionController::Base+ unless +api_only+ is set, which changes the default to
+  # +ActionController::API+. The return value of this option must be a stringified class name.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-controllers
+  #
+  # base_controller 'ApplicationController'
+
+  # Reuse access token for the same resource owner within an application (disabled by default).
+  #
+  # This option protects your application from creating new tokens before old **valid** one becomes
+  # expired so your database doesn't bloat. Keep in mind that when this option is enabled Doorkeeper
+  # doesn't update existing token expiration time, it will create a new token instead if no active matching
+  # token found for the application, resources owner and/or set of scopes.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
+  #
+  # You can not enable this option together with +hash_token_secrets+.
+  #
+  # reuse_access_token
+
+  # In case you enabled `reuse_access_token` option Doorkeeper will try to find matching
+  # token using `matching_token_for` Access Token API that searches for valid records
+  # in batches in order not to pollute the memory with all the database records. By default
+  # Doorkeeper uses batch size of 10 000 records. You can increase or decrease this value
+  # depending on your needs and server capabilities.
+  #
+  # token_lookup_batch_size 10_000
+
+  # Set a limit for token_reuse if using reuse_access_token option
+  #
+  # This option limits token_reusability to some extent.
+  # If not set then access_token will be reused unless it expires.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1189
+  #
+  # This option should be a percentage(i.e. (0,100])
+  #
+  # token_reuse_limit 100
+
+  # Only allow one valid access token obtained via client credentials
+  # per client. If a new access token is obtained before the old one
+  # expired, the old one gets revoked (disabled by default)
+  #
+  # When enabling this option, make sure that you do not expect multiple processes
+  # using the same credentials at the same time (e.g. web servers spanning
+  # multiple machines and/or processes).
+  #
+  # revoke_previous_client_credentials_token
+
+  # Only allow one valid access token obtained via authorization code
+  # per client. If a new access token is obtained before the old one
+  # expired, the old one gets revoked (disabled by default)
+  #
+  # revoke_previous_authorization_code_token
+
+  # Require non-confidential clients to use PKCE when using an authorization code
+  # to obtain an access_token (disabled by default)
+  #
+  # force_pkce
+
+  # Hash access and refresh tokens before persisting them.
+  # This will disable the possibility to use +reuse_access_token+
+  # since plain values can no longer be retrieved.
+  #
+  # Note: If you are already a user of doorkeeper and have existing tokens
+  # in your installation, they will be invalid without adding 'fallback: :plain'.
+  #
+  # hash_token_secrets
+  # By default, token secrets will be hashed using the
+  # +Doorkeeper::Hashing::SHA256+ strategy.
+  #
+  # If you wish to use another hashing implementation, you can override
+  # this strategy as follows:
+  #
+  # hash_token_secrets using: '::Doorkeeper::Hashing::MyCustomHashImpl'
+  #
+  # Keep in mind that changing the hashing function will invalidate all existing
+  # secrets, if there are any.
+
+  # Hash application secrets before persisting them.
+  #
+  # hash_application_secrets
+  #
+  # By default, applications will be hashed
+  # with the +Doorkeeper::SecretStoring::SHA256+ strategy.
+  #
+  # If you wish to use bcrypt for application secret hashing, uncomment
+  # this line instead:
+  #
+  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
+
+  # When the above option is enabled, and a hashed token or secret is not found,
+  # you can allow to fall back to another strategy. For users upgrading
+  # doorkeeper and wishing to enable hashing, you will probably want to enable
+  # the fallback to plain tokens.
+  #
+  # This will ensure that old access tokens and secrets
+  # will remain valid even if the hashing above is enabled.
+  #
+  # This can be done by adding 'fallback: plain', e.g. :
+  #
+  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt', fallback: :plain
+
+  # Issue access tokens with refresh token (disabled by default), you may also
+  # pass a block which accepts `context` to customize when to give a refresh
+  # token or not. Similar to +custom_access_token_expires_in+, `context` has
+  # the following properties:
+  #
+  # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #
+  # use_refresh_token
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter confirmation: true (default: false) if you want to enforce ownership of
+  # a registered application
+  # NOTE: you must also run the rails g doorkeeper:application_owner generator
+  # to provide the necessary support
+  #
+  # enable_application_owner confirmation: false
+
+  # Define access token scopes for your provider
+  # For more information go to
+  # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
+  #
+  default_scopes  :public
+  # optional_scopes :write, :update
+
+  # Allows to restrict only certain scopes for grant_type.
+  # By default, all the scopes will be available for all the grant types.
+  #
+  # Keys to this hash should be the name of grant_type and
+  # values should be the array of scopes for that grant type.
+  # Note: scopes should be from configured_scopes (i.e. default or optional)
+  #
+  # scopes_by_grant_type password: [:write], client_credentials: [:update]
+
+  # Forbids creating/updating applications with arbitrary scopes that are
+  # not in configuration, i.e. +default_scopes+ or +optional_scopes+.
+  # (disabled by default)
+  #
+  # enforce_configured_scopes
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
+  # by default in non-development environments). OAuth2 delegates security in
+  # communication to the HTTPS protocol so it is wise to keep this enabled.
+  #
+  # Callable objects such as proc, lambda, block or any object that responds to
+  # #call can be used in order to allow conditional checks (to allow non-SSL
+  # redirects to localhost for example).
+  #
+  force_ssl_in_redirect_uri !Rails.env.test?
+  #
+  # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
+
+  # Specify what redirect URI's you want to block during Application creation.
+  # Any redirect URI is allowed by default.
+  #
+  # You can use this option in order to forbid URI's with 'javascript' scheme
+  # for example.
+  #
+  # forbid_redirect_uri { |uri| uri.scheme.to_s.downcase == 'javascript' }
+
+  # Allows to set blank redirect URIs for Applications in case Doorkeeper configured
+  # to use URI-less OAuth grant flows like Client Credentials or Resource Owner
+  # Password Credentials. The option is on by default and checks configured grant
+  # types, but you **need** to manually drop `NOT NULL` constraint from `redirect_uri`
+  # column for `oauth_applications` database table.
+  #
+  # You can completely disable this feature with:
+  #
+  # allow_blank_redirect_uri false
+  #
+  # Or you can define your custom check:
+  #
+  # allow_blank_redirect_uri do |grant_flows, client|
+  #   client.superapp?
+  # end
+
+  # Specify how authorization errors should be handled.
+  # By default, doorkeeper renders json errors when access token
+  # is invalid, expired, revoked or has invalid scopes.
+  #
+  # If you want to render error response yourself (i.e. rescue exceptions),
+  # set +handle_auth_errors+ to `:raise` and rescue Doorkeeper::Errors::InvalidToken
+  # or following specific errors:
+  #
+  #   Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
+  #   Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
+  #
+  # handle_auth_errors :raise
+  #
+  # If you want to redirect back to the client application in accordance with
+  # https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1, you can set
+  # +handle_auth_errors+ to :redirect
+  #
+  # handle_auth_errors :redirect
+
+  # Customize token introspection response.
+  # Allows to add your own fields to default one that are required by the OAuth spec
+  # for the introspection response. It could be `sub`, `aud` and so on.
+  # This configuration option can be a proc, lambda or any Ruby object responds
+  # to `.call` method and result of it's invocation must be a Hash.
+  #
+  # custom_introspection_response do |token, context|
+  #   {
+  #     "sub": "Z5O3upPC88QrAjx00dis",
+  #     "aud": "https://protected.example.net/resource",
+  #     "username": User.find(token.resource_owner_id).username
+  #   }
+  # end
+  #
+  # or
+  #
+  # custom_introspection_response CustomIntrospectionResponder
+
+  # Specify what grant flows are enabled in array of Strings. The valid
+  # strings and the flows they enable are:
+  #
+  # "authorization_code" => Authorization Code Grant Flow
+  # "implicit"           => Implicit Grant Flow
+  # "password"           => Resource Owner Password Credentials Grant Flow
+  # "client_credentials" => Client Credentials Grant Flow
+  #
+  # If not specified, Doorkeeper enables authorization_code and
+  # client_credentials.
+  #
+  # implicit and password grant flows have risks that you should understand
+  # before enabling:
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.3
+  #
+  # grant_flows %w[authorization_code client_credentials]
+
+  # Allows to customize OAuth grant flows that +each+ application support.
+  # You can configure a custom block (or use a class respond to `#call`) that must
+  # return `true` in case Application instance supports requested OAuth grant flow
+  # during the authorization request to the server. This configuration +doesn't+
+  # set flows per application, it only allows to check if application supports
+  # specific grant flow.
+  #
+  # For example you can add an additional database column to `oauth_applications` table,
+  # say `t.array :grant_flows, default: []`, and store allowed grant flows that can
+  # be used with this application there. Then when authorization requested Doorkeeper
+  # will call this block to check if specific Application (passed with client_id and/or
+  # client_secret) is allowed to perform the request for the specific grant type
+  # (authorization, password, client_credentials, etc).
+  #
+  # Example of the block:
+  #
+  #   ->(flow, client) { client.grant_flows.include?(flow) }
+  #
+  # In case this option invocation result is `false`, Doorkeeper server returns
+  # :unauthorized_client error and stops the request.
+  #
+  # @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
+  # @return [Boolean] `true` if allow or `false` if forbid the request
+  #
+  # allow_grant_flow_for_client do |grant_flow, client|
+  #   # `grant_flows` is an Array column with grant
+  #   # flows that application supports
+  #
+  #   client.grant_flows.include?(grant_flow)
+  # end
+
+  # If you need arbitrary Resource Owner-Client authorization you can enable this option
+  # and implement the check your need. Config option must respond to #call and return
+  # true in case resource owner authorized for the specific application or false in other
+  # cases.
+  #
+  # By default all Resource Owners are authorized to any Client (application).
+  #
+  # authorize_resource_owner_for_client do |client, resource_owner|
+  #   resource_owner.admin? || client.owners_allowlist.include?(resource_owner)
+  # end
+
+  # Allows additional data fields to be sent while granting access to an application,
+  # and for this additional data to be included in subsequently generated access tokens.
+  # The 'authorizations/new' page will need to be overridden to include this additional data
+  # in the request params when granting access. The access grant and access token models
+  # will both need to respond to these additional data fields, and have a database column
+  # to store them in.
+  #
+  # Example:
+  # You have a multi-tenanted platform and want to be able to grant access to a specific
+  # tenant, rather than all the tenants a user has access to. You can use this config
+  # option to specify that a ':tenant_id' will be passed when authorizing. This tenant_id
+  # will be included in the access tokens. When a request is made with one of these access
+  # tokens, you can check that the requested data belongs to the specified tenant.
+  #
+  # Default value is an empty Array: []
+  # custom_access_token_attributes [:tenant_id]
+
+  # Hook into the strategies' request & response life-cycle in case your
+  # application needs advanced customization or logging:
+  #
+  # before_successful_strategy_response do |request|
+  #   puts "BEFORE HOOK FIRED! #{request}"
+  # end
+  #
+  # after_successful_strategy_response do |request, response|
+  #   puts "AFTER HOOK FIRED! #{request}, #{response}"
+  # end
+
+  # Hook into Authorization flow in order to implement Single Sign Out
+  # or add any other functionality. Inside the block you have an access
+  # to `controller` (authorizations controller instance) and `context`
+  # (Doorkeeper::OAuth::Hooks::Context instance) which provides pre auth
+  # or auth objects with issued token based on hook type (before or after).
+  #
+  # before_successful_authorization do |controller, context|
+  #   Rails.logger.info(controller.request.params.inspect)
+  #
+  #   Rails.logger.info(context.pre_auth.inspect)
+  # end
+  #
+  # after_successful_authorization do |controller, context|
+  #   controller.session[:logout_urls] <<
+  #     Doorkeeper::Application
+  #       .find_by(controller.request.params.slice(:redirect_uri))
+  #       .logout_uri
+  #
+  #   Rails.logger.info(context.auth.inspect)
+  #   Rails.logger.info(context.issued_token)
+  # end
+
+  # Under some circumstances you might want to have applications auto-approved,
+  # so that the user skips the authorization step.
+  # For example if dealing with a trusted application.
+  #
+  # skip_authorization do |resource_owner, client|
+  #   client.superapp? or resource_owner.admin?
+  # end
+
+  # Configure custom constraints for the Token Introspection request.
+  # By default this configuration option allows to introspect a token by another
+  # token of the same application, OR to introspect the token that belongs to
+  # authorized client (from authenticated client) OR when token doesn't
+  # belong to any client (public token). Otherwise requester has no access to the
+  # introspection and it will return response as stated in the RFC.
+  #
+  # Block arguments:
+  #
+  # @param token [Doorkeeper::AccessToken]
+  #   token to be introspected
+  #
+  # @param authorized_client [Doorkeeper::Application]
+  #   authorized client (if request is authorized using Basic auth with
+  #   Client Credentials for example)
+  #
+  # @param authorized_token [Doorkeeper::AccessToken]
+  #   Bearer token used to authorize the request
+  #
+  # In case the block returns `nil` or `false` introspection responses with 401 status code
+  # when using authorized token to introspect, or you'll get 200 with { "active": false } body
+  # when using authorized client to introspect as stated in the
+  # RFC 7662 section 2.2. Introspection Response.
+  #
+  # Using with caution:
+  # Keep in mind that these three parameters pass to block can be nil as following case:
+  #  `authorized_client` is nil if and only if `authorized_token` is present, and vice versa.
+  #  `token` will be nil if and only if `authorized_token` is present.
+  # So remember to use `&` or check if it is present before calling method on
+  # them to make sure you doesn't get NoMethodError exception.
+  #
+  # You can define your custom check:
+  #
+  # allow_token_introspection do |token, authorized_client, authorized_token|
+  #   if authorized_token
+  #     # customize: require `introspection` scope
+  #     authorized_token.application == token&.application ||
+  #       authorized_token.scopes.include?("introspection")
+  #   elsif token.application
+  #     # `protected_resource` is a new database boolean column, for example
+  #     authorized_client == token.application || authorized_client.protected_resource?
+  #   else
+  #     # public token (when token.application is nil, token doesn't belong to any application)
+  #     true
+  #   end
+  # end
+  #
+  # Or you can completely disable any token introspection:
+  #
+  # allow_token_introspection false
+  #
+  # If you need to block the request at all, then configure your routes.rb or web-server
+  # like nginx to forbid the request.
+
+  # WWW-Authenticate Realm (default: "Doorkeeper").
+  #
+  # realm "Doorkeeper"
+end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,155 @@
+en:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: 'Name'
+        redirect_uri: 'Redirect URI'
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              invalid_uri: 'must be a valid URI.'
+              unspecified_scheme: 'must specify a scheme.'
+              relative_uri: 'must be an absolute URI.'
+              secured_uri: 'must be an HTTPS/SSL URI.'
+              forbidden_uri: 'is forbidden by the server.'
+            scopes:
+              not_match_configured: "doesn't match configured on the server."
+
+  doorkeeper:
+    applications:
+      confirmations:
+        destroy: 'Are you sure?'
+      buttons:
+        edit: 'Edit'
+        destroy: 'Destroy'
+        submit: 'Submit'
+        cancel: 'Cancel'
+        authorize: 'Authorize'
+      form:
+        error: 'Whoops! Check your form for possible errors'
+      help:
+        confidential: 'Application will be used where the client secret can be kept confidential. Native mobile apps and Single Page Apps are considered non-confidential.'
+        redirect_uri: 'Use one line per URI'
+        blank_redirect_uri: "Leave it blank if you configured your provider to use Client Credentials, Resource Owner Password Credentials or any other grant type that doesn't require redirect URI."
+        scopes: 'Separate scopes with spaces. Leave blank to use the default scopes.'
+      edit:
+        title: 'Edit application'
+      index:
+        title: 'Your applications'
+        new: 'New Application'
+        name: 'Name'
+        callback_url: 'Callback URL'
+        confidential: 'Confidential?'
+        actions: 'Actions'
+        confidentiality:
+          'yes': 'Yes'
+          'no': 'No'
+      new:
+        title: 'New Application'
+      show:
+        title: 'Application: %{name}'
+        application_id: 'UID'
+        secret: 'Secret'
+        secret_hashed: 'Secret hashed'
+        scopes: 'Scopes'
+        confidential: 'Confidential'
+        callback_urls: 'Callback urls'
+        actions: 'Actions'
+        not_defined: 'Not defined'
+
+    authorizations:
+      buttons:
+        authorize: 'Authorize'
+        deny: 'Deny'
+      error:
+        title: 'An error has occurred'
+      new:
+        title: 'Authorization required'
+        prompt: 'Authorize %{client_name} to use your account?'
+        able_to: 'This application will be able to'
+      show:
+        title: 'Authorization code'
+      form_post:
+        title: 'Submit this form'
+
+    authorized_applications:
+      confirmations:
+        revoke: 'Are you sure?'
+      buttons:
+        revoke: 'Revoke'
+      index:
+        title: 'Your authorized applications'
+        application: 'Application'
+        created_at: 'Created At'
+        date_format: '%Y-%m-%d %H:%M:%S'
+
+    pre_authorization:
+      status: 'Pre-authorization'
+
+    errors:
+      messages:
+        # Common error messages
+        invalid_request:
+          unknown: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+          missing_param: 'Missing required parameter: %{value}.'
+          request_not_authorized: 'Request need to be authorized. Required parameter for authorizing request is missing or invalid.'
+          invalid_code_challenge: 'Code challenge is required.'
+        invalid_redirect_uri: "The requested redirect uri is malformed or doesn't match client redirect URI."
+        unauthorized_client: 'The client is not authorized to perform this request using this method.'
+        access_denied: 'The resource owner or authorization server denied the request.'
+        invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
+        invalid_code_challenge_method:
+          zero: 'The authorization server does not support PKCE as there are no accepted code_challenge_method values.'
+          one: 'The code_challenge_method must be %{challenge_methods}.'
+          other: 'The code_challenge_method must be one of %{challenge_methods}.'
+        server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
+        temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+
+        # Configuration error messages
+        credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
+        resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured.'
+        admin_authenticator_not_configured: 'Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured.'
+
+        # Access grant errors
+        unsupported_response_type: 'The authorization server does not support this response type.'
+        unsupported_response_mode: 'The authorization server does not support this response mode.'
+
+        # Access token errors
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+        unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+        revoke:
+          unauthorized: "You are not authorized to revoke this token"
+
+        forbidden_token:
+          missing_scope: 'Access to this resource requires scope "%{oauth_scopes}".'
+
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'
+
+    layouts:
+      admin:
+        title: 'Doorkeeper'
+        nav:
+          oauth2_provider: 'OAuth2 Provider'
+          applications: 'Applications'
+          home: 'Home'
+      application:
+        title: 'OAuth authorization required'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  use_doorkeeper
   resources :rewards, only: [:index]
 
   root to: 'questions#index'
@@ -32,6 +33,16 @@ Rails.application.routes.draw do
       post 'upvote'
       post 'downvote'
       delete 'cancel'
+    end
+  end
+
+  namespace :api do
+    namespace :v1 do
+      resources :profiles, only: [] do
+        get :me, on: :collection
+      end
+
+      resources :questions, only: :index
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,11 +38,13 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :profiles, only: [] do
+      resources :profiles, only: [:index] do
         get :me, on: :collection
       end
 
-      resources :questions, only: :index
+      resources :questions, only: %i[index show create update destroy] do
+        resources :answers, only: %i[index show create update destroy], shallow: true
+      end
     end
   end
 

--- a/db/migrate/20250710112840_create_doorkeeper_tables.rb
+++ b/db/migrate/20250710112840_create_doorkeeper_tables.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+class CreateDoorkeeperTables < ActiveRecord::Migration[7.1]
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,    null: false
+      t.string  :uid,     null: false
+      # Remove `null: false` or use conditional constraint if you are planning to use public clients.
+      t.string  :secret,  null: false
+
+      # Remove `null: false` if you are planning to use grant flows
+      # that doesn't require redirect URI to be used during authorization
+      # like Client Credentials flow or Resource Owner Password.
+      t.text    :redirect_uri, null: false
+      t.string  :scopes,       null: false, default: ''
+      t.boolean :confidential, null: false, default: true
+      t.timestamps             null: false
+    end
+
+    add_index :oauth_applications, :uid, unique: true
+
+    create_table :oauth_access_grants do |t|
+      t.references :resource_owner,  null: false
+      t.references :application,     null: false
+      t.string   :token,             null: false
+      t.integer  :expires_in,        null: false
+      t.text     :redirect_uri,      null: false
+      t.string   :scopes,            null: false, default: ''
+      t.datetime :created_at,        null: false
+      t.datetime :revoked_at
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+    add_foreign_key(
+      :oauth_access_grants,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    create_table :oauth_access_tokens do |t|
+      t.references :resource_owner, index: true
+
+      # Remove `null: false` if you are planning to use Password
+      # Credentials Grant flow that doesn't require an application.
+      t.references :application,    null: false
+
+      # If you use a custom token generator you may need to change this column
+      # from string to text, so that it accepts tokens larger than 255
+      # characters. More info on custom token generators in:
+      # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
+      #
+      # t.text :token, null: false
+      t.string :token, null: false
+
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.string   :scopes
+      t.datetime :created_at, null: false
+      t.datetime :revoked_at
+
+      # The authorization server MAY issue a new refresh token, in which case
+      # *the client MUST discard the old refresh token* and replace it with the
+      # new refresh token. The authorization server MAY revoke the old
+      # refresh token after issuing a new refresh token to the client.
+      # @see https://datatracker.ietf.org/doc/html/rfc6749#section-6
+      #
+      # Doorkeeper implementation: if there is a `previous_refresh_token` column,
+      # refresh tokens will be revoked after a related access token is used.
+      # If there is no `previous_refresh_token` column, previous tokens are
+      # revoked as soon as a new access token is created.
+      #
+      # Comment out this line if you want refresh tokens to be instantly
+      # revoked after use.
+      t.string   :previous_refresh_token, null: false, default: ""
+    end
+
+    add_index :oauth_access_tokens, :token, unique: true
+
+    # See https://github.com/doorkeeper-gem/doorkeeper/issues/1592
+    if ActiveRecord::Base.connection.adapter_name == "SQLServer"
+      execute <<~SQL.squish
+        CREATE UNIQUE NONCLUSTERED INDEX index_oauth_access_tokens_on_refresh_token ON oauth_access_tokens(refresh_token)
+        WHERE refresh_token IS NOT NULL
+      SQL
+    else
+      add_index :oauth_access_tokens, :refresh_token, unique: true
+    end
+
+    add_foreign_key(
+      :oauth_access_tokens,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    # Uncomment below to ensure a valid reference to the resource owner's table
+    # add_foreign_key :oauth_access_grants, <model>, column: :resource_owner_id
+    # add_foreign_key :oauth_access_tokens, <model>, column: :resource_owner_id
+  end
+end

--- a/db/migrate/20250710112840_create_doorkeeper_tables.rb
+++ b/db/migrate/20250710112840_create_doorkeeper_tables.rb
@@ -71,13 +71,13 @@ class CreateDoorkeeperTables < ActiveRecord::Migration[7.1]
       #
       # Comment out this line if you want refresh tokens to be instantly
       # revoked after use.
-      t.string   :previous_refresh_token, null: false, default: ""
+      t.string   :previous_refresh_token, null: false, default: ''
     end
 
     add_index :oauth_access_tokens, :token, unique: true
 
     # See https://github.com/doorkeeper-gem/doorkeeper/issues/1592
-    if ActiveRecord::Base.connection.adapter_name == "SQLServer"
+    if ActiveRecord::Base.connection.adapter_name == 'SQLServer'
       execute <<~SQL.squish
         CREATE UNIQUE NONCLUSTERED INDEX index_oauth_access_tokens_on_refresh_token ON oauth_access_tokens(refresh_token)
         WHERE refresh_token IS NOT NULL

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_04_123927) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_10_112840) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -84,6 +84,48 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_04_123927) do
     t.index ["linkable_type", "linkable_id"], name: "index_links_on_linkable"
   end
 
+  create_table "oauth_access_grants", force: :cascade do |t|
+    t.bigint "resource_owner_id", null: false
+    t.bigint "application_id", null: false
+    t.string "token", null: false
+    t.integer "expires_in", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "revoked_at"
+    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
+    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
+  end
+
+  create_table "oauth_access_tokens", force: :cascade do |t|
+    t.bigint "resource_owner_id"
+    t.bigint "application_id", null: false
+    t.string "token", null: false
+    t.string "refresh_token"
+    t.integer "expires_in"
+    t.string "scopes"
+    t.datetime "created_at", null: false
+    t.datetime "revoked_at"
+    t.string "previous_refresh_token", default: "", null: false
+    t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
+  end
+
+  create_table "oauth_applications", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "uid", null: false
+    t.string "secret", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.boolean "confidential", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
   create_table "questions", force: :cascade do |t|
     t.string "title", null: false
     t.text "body", null: false
@@ -138,6 +180,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_04_123927) do
   add_foreign_key "answers", "users", column: "author_id"
   add_foreign_key "authorizations", "users"
   add_foreign_key "comments", "users"
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "questions", "users", column: "author_id"
   add_foreign_key "rewards", "questions"
   add_foreign_key "rewards", "users"

--- a/spec/api/v1/answer_spec.rb
+++ b/spec/api/v1/answer_spec.rb
@@ -1,0 +1,213 @@
+require 'rails_helper'
+
+describe 'Answers API for Question', type: :request do
+  let(:headers)         { { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' } }
+  let(:user)            { create(:user) }
+  let(:access_token)    { create(:access_token, resource_owner_id: user.id) }
+  let!(:question)       { create(:question, author: user) }
+  let!(:answers)        { create_list(:answer, 3, question: question, author: user) }
+
+  describe 'GET /api/v1/questions/:question_id/answers' do
+    let(:method)   { :get }
+    let(:api_path) { "/api/v1/questions/#{question.id}/answers" }
+
+    it_behaves_like 'API Authorizable'
+
+    context 'authorized' do
+      before do
+        get api_path,
+            params: { access_token: access_token.token },
+            headers: headers
+      end
+
+      it_behaves_like 'Status OK'
+
+      it 'returns list of answers' do
+        expect(json['answers'].size).to eq 3
+      end
+
+      it_behaves_like 'Return public fields' do
+        let(:fields)            { %w[id body author_id created_at updated_at] }
+        let(:resource_response) { json['answers'].first }
+        let(:resource)          { answers.first }
+      end
+
+      it 'returns attached files as URLs even if they empty' do
+        expect(json['answers'].first['files']).to eq []
+      end
+    end
+  end
+
+  describe 'GET /api/v1/answers/:id' do
+    let!(:answer)  { create(:answer, :with_file, question: question, author: user) }
+    let!(:link)    { create(:link,    linkable: answer) }
+    let!(:comment) { create(:comment, commentable: answer, user: user) }
+
+    let(:method)   { :get }
+    let(:api_path) { "/api/v1/answers/#{answer.id}" }
+
+    it_behaves_like 'API Authorizable'
+
+    context 'authorized' do
+      before do
+        get api_path,
+            params: { access_token: access_token.token },
+            headers: headers
+      end
+
+      it_behaves_like 'Status OK'
+
+      it_behaves_like 'Return public fields' do
+        let(:fields)            { %w[id body author_id created_at updated_at] }
+        let(:resource_response) { json['answer'] }
+        let(:resource)          { answer }
+      end
+
+      it 'returns attached files as URLs' do
+        expected_urls = answer.files.map do |f|
+          Rails.application.routes.url_helpers.rails_blob_url(f, only_path: false)
+        end
+        expect(json['answer']['files']).to match_array(expected_urls)
+      end
+
+      it 'returns list of links' do
+        expect(json['answer']['links']).to contain_exactly(
+          a_hash_including(
+            'id' => link.id,
+            'name' => link.name,
+            'url' => link.url
+          )
+        )
+      end
+
+      it 'returns list of comments with nested user' do
+        comment_json = json['answer']['comments'].first
+
+        expect(comment_json['id']).to eq comment.id
+        expect(comment_json['body']).to eq comment.body
+
+        %w[created_at updated_at].each do |attr|
+          parsed = Time.iso8601(comment_json[attr])
+          expect(parsed).to be_within(1.second).of(comment.send(attr))
+        end
+
+        expect(comment_json['user']['id']).to eq user.id
+      end
+    end
+  end
+
+  describe 'POST /api/v1/questions/:question_id/answers' do
+    let(:method)       { :post }
+    let(:api_path)     { "/api/v1/questions/#{question.id}/answers" }
+    let(:valid_params) { { answer: { body: 'New answer body' } } }
+    let(:invalid_params) { { answer: { body: '' } } }
+
+    it_behaves_like 'API Authorizable'
+
+    context 'authorized' do
+      let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+
+      before do
+        post api_path,
+             params: valid_params.merge(access_token: access_token.token),
+             headers: headers,
+             as: :json
+      end
+
+      it 'creates answer (201) and returns its JSON' do
+        expect(response.status).to eq 201
+        expect(question.answers.count).to eq 4
+        expect(json['answer']['body']).to eq 'New answer body'
+        expect(json['answer']['author_id']).to eq user.id
+      end
+
+      it_behaves_like 'Return public fields' do
+        let(:fields)            { %w[id body author_id created_at updated_at] }
+        let(:resource_response) { json['answer'] }
+        let(:resource)          { question.answers.last }
+      end
+
+      context 'invalid params' do
+        before do
+          post api_path,
+               params: invalid_params.merge(access_token: access_token.token),
+               headers: headers,
+               as: :json
+        end
+
+        it 'returns 422 and error messages' do
+          expect(response.status).to eq 422
+          expect(json['errors']).to be_present
+        end
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/answers/:id' do
+    let!(:answer)       { create(:answer, question: question, author: user, body: 'Old body') }
+    let(:method)        { :patch }
+    let(:api_path)      { "/api/v1/answers/#{answer.id}" }
+    let(:valid_params)  { { answer: { body: 'Updated body' } } }
+    let(:invalid_params) { { answer: { body: '' } } }
+
+    it_behaves_like 'API Authorizable'
+
+    context 'authorized' do
+      before do
+        patch api_path,
+              params: valid_params.merge(access_token: access_token.token),
+              headers: headers,
+              as: :json
+        answer.reload
+      end
+
+      it 'updates answer (200) and returns JSON' do
+        expect(response.status).to eq 200
+        expect(answer.body).to eq 'Updated body'
+        expect(json['answer']['body']).to eq 'Updated body'
+      end
+
+      it_behaves_like 'Return public fields' do
+        let(:fields)            { %w[id body author_id created_at updated_at] }
+        let(:resource_response) { json['answer'] }
+        let(:resource)          { answer }
+      end
+
+      context 'invalid params' do
+        before do
+          patch api_path,
+                params: invalid_params.merge(access_token: access_token.token),
+                headers: headers,
+                as: :json
+        end
+
+        it 'returns 422 and error messages' do
+          expect(response.status).to eq 422
+          expect(json['errors']).to be_present
+        end
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/answers/:id' do
+    let!(:answer)  { create(:answer, question: question, author: user) }
+    let(:method)   { :delete }
+    let(:api_path) { "/api/v1/answers/#{answer.id}" }
+
+    it_behaves_like 'API Authorizable'
+
+    context 'authorized' do
+      it 'deletes answer (200) and returns deleted JSON' do
+        expect do
+          delete api_path,
+                 params: { access_token: access_token.token },
+                 headers: headers,
+                 as: :json
+        end.to change(Answer, :count).by(-1)
+
+        expect(response.status).to eq 200
+        expect(json['answer']['id']).to eq answer.id
+      end
+    end
+  end
+end

--- a/spec/api/v1/answer_spec.rb
+++ b/spec/api/v1/answer_spec.rb
@@ -13,7 +13,7 @@ describe 'Answers API for Question', type: :request do
 
     it_behaves_like 'API Authorizable'
 
-    context 'authorized' do
+    context 'when authorized' do
       before do
         get api_path,
             params: { access_token: access_token.token },
@@ -48,7 +48,7 @@ describe 'Answers API for Question', type: :request do
 
     it_behaves_like 'API Authorizable'
 
-    context 'authorized' do
+    context 'when authorized' do
       before do
         get api_path,
             params: { access_token: access_token.token },
@@ -104,7 +104,7 @@ describe 'Answers API for Question', type: :request do
 
     it_behaves_like 'API Authorizable'
 
-    context 'authorized' do
+    context 'when authorized' do
       let(:access_token) { create(:access_token, resource_owner_id: user.id) }
 
       before do
@@ -127,7 +127,7 @@ describe 'Answers API for Question', type: :request do
         let(:resource)          { question.answers.last }
       end
 
-      context 'invalid params' do
+      context 'with invalid params' do
         before do
           post api_path,
                params: invalid_params.merge(access_token: access_token.token),
@@ -152,7 +152,7 @@ describe 'Answers API for Question', type: :request do
 
     it_behaves_like 'API Authorizable'
 
-    context 'authorized' do
+    context 'when authorized' do
       before do
         patch api_path,
               params: valid_params.merge(access_token: access_token.token),
@@ -173,7 +173,7 @@ describe 'Answers API for Question', type: :request do
         let(:resource)          { answer }
       end
 
-      context 'invalid params' do
+      context 'with invalid params' do
         before do
           patch api_path,
                 params: invalid_params.merge(access_token: access_token.token),
@@ -196,7 +196,7 @@ describe 'Answers API for Question', type: :request do
 
     it_behaves_like 'API Authorizable'
 
-    context 'authorized' do
+    context 'when authorized' do
       it 'deletes answer (200) and returns deleted JSON' do
         expect do
           delete api_path,

--- a/spec/api/v1/profiles_spec.rb
+++ b/spec/api/v1/profiles_spec.rb
@@ -9,7 +9,7 @@ describe 'Profiles API', type: :request do
       let(:method) { :get }
     end
 
-    context 'authorized!' do
+    context 'when authorized!' do
       let(:me) { create(:user) }
       let(:access_token) { create(:access_token, resource_owner_id: me.id) }
 
@@ -37,7 +37,7 @@ describe 'Profiles API', type: :request do
       let(:method) { :get }
     end
 
-    context 'authorized!' do
+    context 'when authorized!' do
       let(:me) { create(:user) }
       let!(:users) { create_list(:user, 3) }
       let(:access_token) { create(:access_token, resource_owner_id: me.id) }

--- a/spec/api/v1/profiles_spec.rb
+++ b/spec/api/v1/profiles_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe 'Profiles API', type: :request do
+  let(:headers) { { "CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json" } }
+
+  describe 'GET /api/v1/profiles/me' do
+    context 'unauthorized' do
+      it 'returns status: 401 if there is no access_token' do
+        get '/api/v1/profiles/me', headers: headers
+        expect(response.status).to eq 401
+      end
+
+      it 'returns status: 401 if access_token is invalid' do
+        get '/api/v1/profiles/me', params: { access_token: '1234' }, headers: headers
+        expect(response.status).to eq 401
+      end
+    end
+
+    context 'authorized!' do
+      let(:me) { create(:user) }
+      let(:access_token) { create(:access_token, resource_owner_id: me.id) }
+
+      before { get '/api/v1/profiles/me', params: { access_token: access_token.token }, headers: headers }
+
+      it 'returns 200 status' do
+        expect(response).to be_successful
+      end
+
+      it 'returns all public fields' do
+        %w[id created_at updated_at email admin].each do |attr|
+          expect(json[attr]).to eq me.send(attr).as_json
+        end
+      end
+
+      it 'does no return private fields' do
+        %w[password encrypted_password].each do |attr|
+          expect(json).to_not have_key(attr)
+        end
+      end
+    end
+  end
+end
+

--- a/spec/api/v1/profiles_spec.rb
+++ b/spec/api/v1/profiles_spec.rb
@@ -1,19 +1,12 @@
 require 'rails_helper'
 
 describe 'Profiles API', type: :request do
-  let(:headers) { { "CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json" } }
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' } }
 
   describe 'GET /api/v1/profiles/me' do
-    context 'unauthorized' do
-      it 'returns status: 401 if there is no access_token' do
-        get '/api/v1/profiles/me', headers: headers
-        expect(response.status).to eq 401
-      end
-
-      it 'returns status: 401 if access_token is invalid' do
-        get '/api/v1/profiles/me', params: { access_token: '1234' }, headers: headers
-        expect(response.status).to eq 401
-      end
+    it_behaves_like 'API Authorizable' do
+      let(:api_path) { '/api/v1/profiles/me' }
+      let(:method) { :get }
     end
 
     context 'authorized!' do
@@ -22,22 +15,52 @@ describe 'Profiles API', type: :request do
 
       before { get '/api/v1/profiles/me', params: { access_token: access_token.token }, headers: headers }
 
-      it 'returns 200 status' do
-        expect(response).to be_successful
-      end
+      it_behaves_like 'Status OK'
 
       it 'returns all public fields' do
         %w[id created_at updated_at email admin].each do |attr|
-          expect(json[attr]).to eq me.send(attr).as_json
+          expect(json['user'][attr]).to eq me.send(attr).as_json
         end
       end
 
       it 'does no return private fields' do
         %w[password encrypted_password].each do |attr|
-          expect(json).to_not have_key(attr)
+          expect(json).not_to have_key(attr)
+        end
+      end
+    end
+  end
+
+  describe 'GET /api/v1/profiles' do
+    it_behaves_like 'API Authorizable' do
+      let(:api_path) { '/api/v1/profiles' }
+      let(:method) { :get }
+    end
+
+    context 'authorized!' do
+      let(:me) { create(:user) }
+      let!(:users) { create_list(:user, 3) }
+      let(:access_token) { create(:access_token, resource_owner_id: me.id) }
+
+      before { get '/api/v1/profiles', params: { access_token: access_token.token }, headers: headers }
+
+      it 'returns 200 status' do
+        expect(response).to be_successful
+      end
+
+      it 'returns all users except me' do
+        returned_ids = json['users'].map { |u| u['id'] }
+        expect(returned_ids).to match_array(users.pluck(:id))
+        expect(returned_ids).not_to include(me.id)
+      end
+
+      it 'returns all public fields' do
+        json['users'].each_with_index do |profile, idx|
+          %w[id created_at updated_at email admin].each do |attr|
+            expect(profile[attr]).to eq users[idx].send(attr).as_json
+          end
         end
       end
     end
   end
 end
-

--- a/spec/api/v1/questions_spec.rb
+++ b/spec/api/v1/questions_spec.rb
@@ -1,19 +1,13 @@
 require 'rails_helper'
 
 describe 'Questions API', type: :request do
-  let(:headers) { { "CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json" } }
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' } }
 
   describe 'GET /api/v1/questions' do
-    context 'unauthorized' do
-      it 'returns status: 401 if there is no access_token' do
-        get '/api/v1/questions', headers: headers
-        expect(response.status).to eq 401
-      end
+    let(:api_path) { '/api/v1/questions' }
 
-      it 'returns status: 401 if access_token is invalid' do
-        get '/api/v1/questions', params: { access_token: '1234' }, headers: headers
-        expect(response.status).to eq 401
-      end
+    it_behaves_like 'API Authorizable' do
+      let(:method) { :get }
     end
 
     context 'authorized!' do
@@ -21,23 +15,29 @@ describe 'Questions API', type: :request do
       let(:access_token) { create(:access_token) }
       let!(:questions) { create_list(:question, 2) }
       let(:question) { questions.first }
-      let(:question_response) { json.first }
+      let(:question_response) { json['questions'].first }
       let!(:answers) { create_list(:answer, 3, question: question, author: user) }
 
-      before { get '/api/v1/questions', params: { access_token: access_token.token }, headers: headers }
+      before { get api_path, params: { access_token: access_token.token }, headers: headers }
 
-      it 'returns 200 status' do
-        expect(response).to be_successful
-      end
+      it_behaves_like 'Status OK'
 
       it 'returns list of questions' do
-        expect(json.size).to eq 2
+        expect(json['questions'].size).to eq 2
       end
 
-      it 'returns all public fields' do
-        %w[id title body author_id created_at updated_at].each do |attr|
-          expect(question_response[attr]).to eq question.send(attr).as_json
-        end
+      it_behaves_like 'Return public fields' do
+        let(:fields) { %w[id title body created_at updated_at] }
+        let(:resource_response) { question_response }
+        let(:resource) { question }
+      end
+
+      it 'contains author object' do
+        expect(question_response['author']['id']).to eq question.author.id
+      end
+
+      it 'contains short title' do
+        expect(question_response['short_title']).to eq question.title.truncate(7)
       end
 
       describe 'answers' do
@@ -48,11 +48,192 @@ describe 'Questions API', type: :request do
           expect(question_response['answers'].size).to eq 3
         end
 
-        it 'returns all public fields' do
-          %w[id body author_id created_at updated_at].each do |attr|
-            expect(answer_response[attr]).to eq answer.send(attr).as_json
-          end
+        it_behaves_like 'Return public fields' do
+          let(:fields) { %w[id author_id body created_at updated_at] }
+          let(:resource_response) { answer_response }
+          let(:resource) { answer }
         end
+      end
+    end
+  end
+
+  describe 'GET /api/v1/questions/:id' do
+    let!(:user)          { create(:user) }
+    let!(:access_token)  { create(:access_token, resource_owner_id: user.id) }
+    let!(:question)      { create(:question, :with_files, author: user) }
+    let!(:link)          { create(:link, linkable: question) }
+    let!(:comment)       { create(:comment, commentable: question, user: user) }
+
+    let(:api_path)       { "/api/v1/questions/#{question.id}" }
+    let(:question_json)  { json['question'] }
+
+    it_behaves_like 'API Authorizable' do
+      let(:method) { :get }
+    end
+
+    context 'authorized' do
+      before do
+        get api_path, params: { access_token: access_token.token }, headers: headers
+      end
+
+      it_behaves_like 'Status OK'
+
+      it_behaves_like 'Return public fields' do
+        let(:fields) { %w[id title body created_at updated_at] }
+        let(:resource_response) { question_json }
+        let(:resource) { question }
+      end
+
+      it 'returns files as URLs' do
+        expected_urls = question.files.map do |f|
+          Rails.application.routes.url_helpers.rails_blob_url(f, only_path: false)
+        end
+        expect(question_json['files']).to match_array expected_urls
+      end
+
+      it 'returns list of links' do
+        expect(question_json['links'].size).to eq 1
+
+        link_json = question_json['links'].first
+        expect(link_json['id']).to eq link.id
+        expect(link_json['name']).to eq link.name
+        expect(link_json['url']).to  eq link.url
+      end
+
+      it 'returns list of comments with nested user' do
+        expect(question_json['comments'].size).to eq 1
+
+        comment_json = question_json['comments'].first
+        expect(comment_json['id']).to         eq comment.id
+        expect(comment_json['body']).to       eq comment.body
+        expect(comment_json['created_at']).to eq comment.created_at.as_json
+        expect(comment_json['updated_at']).to eq comment.updated_at.as_json
+
+        user_json = comment_json['user']
+        expect(user_json['id']).to eq user.id
+      end
+    end
+  end
+
+  describe 'POST /api/v1/questions' do
+    let(:method)       { :post }
+    let(:api_path)     { '/api/v1/questions' }
+    let(:valid_params) { { question: { title: 'API title', body: 'API body' } } }
+    let(:invalid_params) { { question: { title: '', body: '' } } }
+
+    it_behaves_like 'API Authorizable'
+
+    context 'authorized' do
+      let(:access_token) { create(:access_token) }
+
+      before do
+        post api_path,
+             params: valid_params.merge(access_token: access_token.token),
+             headers: headers,
+             as: :json
+      end
+
+      it 'creates question (201) and returns its JSON' do
+        expect(response.status).to eq 201
+        expect(Question.count).to eq 1
+        expect(json['question']['title']).to eq 'API title'
+        expect(json['question']['body']).to  eq 'API body'
+      end
+
+      it_behaves_like 'Return public fields' do
+        let(:fields)            { %w[id title body created_at updated_at] }
+        let(:resource_response) { json['question'] }
+        let(:resource)          { Question.last }
+      end
+
+      context 'invalid params' do
+        before do
+          post api_path,
+               params: invalid_params.merge(access_token: access_token.token),
+               headers: headers,
+               as: :json
+        end
+
+        it 'returns 422 and error messages' do
+          expect(response.status).to eq 422
+          expect(json['errors']).to be_present
+        end
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/questions/:id' do
+    let(:method)        { :patch }
+    let!(:user)         { create(:user) }
+    let!(:question)     { create(:question, author: user, title: 'Old', body: 'Old') }
+    let(:api_path)      { "/api/v1/questions/#{question.id}" }
+    let(:update_params) { { question: { title: 'New', body: 'NewBody' } } }
+
+    it_behaves_like 'API Authorizable'
+
+    context 'authorized' do
+      let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+
+      before do
+        patch api_path,
+              params: update_params.merge(access_token: access_token.token),
+              headers: headers,
+              as: :json
+        question.reload
+      end
+
+      it 'updates question (200) and returns JSON' do
+        expect(response.status).to eq 200
+        expect(question.title).to eq 'New'
+        expect(question.body).to  eq 'NewBody'
+        expect(json['question']['title']).to eq 'New'
+        expect(json['question']['body']).to  eq 'NewBody'
+      end
+
+      it_behaves_like 'Return public fields' do
+        let(:fields)            { %w[id title body created_at updated_at] }
+        let(:resource_response) { json['question'] }
+        let(:resource)          { question }
+      end
+
+      context 'invalid params' do
+        before do
+          patch api_path,
+                params: { question: { title: nil } }
+                  .merge(access_token: access_token.token),
+                headers: headers,
+                as: :json
+        end
+
+        it 'returns 422 and error messages' do
+          expect(response.status).to eq 422
+          expect(json['errors']).to be_present
+        end
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/questions/:id' do
+    let(:method)   { :delete }
+    let!(:user)    { create(:user) }
+    let!(:question) { create(:question, author: user, title: 'X', body: 'Y') }
+    let(:api_path) { "/api/v1/questions/#{question.id}" }
+
+    it_behaves_like 'API Authorizable'
+
+    context 'authorized' do
+      let(:access_token) { create(:access_token, resource_owner_id: user.id) }
+
+      it 'deletes question (200) and returns deleted JSON' do
+        expect do
+          delete api_path,
+                 params: { access_token: access_token.token },
+                 headers: headers,
+                 as: :json
+        end.to change(Question, :count).by(-1)
+
+        expect(response.status).to eq 200
+        expect(json['question']['id']).to eq question.id
       end
     end
   end

--- a/spec/api/v1/questions_spec.rb
+++ b/spec/api/v1/questions_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe 'Questions API', type: :request do
+  let(:headers) { { "CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json" } }
+
+  describe 'GET /api/v1/questions' do
+    context 'unauthorized' do
+      it 'returns status: 401 if there is no access_token' do
+        get '/api/v1/questions', headers: headers
+        expect(response.status).to eq 401
+      end
+
+      it 'returns status: 401 if access_token is invalid' do
+        get '/api/v1/questions', params: { access_token: '1234' }, headers: headers
+        expect(response.status).to eq 401
+      end
+    end
+
+    context 'authorized!' do
+      let(:user) { create(:user) }
+      let(:access_token) { create(:access_token) }
+      let!(:questions) { create_list(:question, 2) }
+      let(:question) { questions.first }
+      let(:question_response) { json.first }
+      let!(:answers) { create_list(:answer, 3, question: question, author: user) }
+
+      before { get '/api/v1/questions', params: { access_token: access_token.token }, headers: headers }
+
+      it 'returns 200 status' do
+        expect(response).to be_successful
+      end
+
+      it 'returns list of questions' do
+        expect(json.size).to eq 2
+      end
+
+      it 'returns all public fields' do
+        %w[id title body author_id created_at updated_at].each do |attr|
+          expect(question_response[attr]).to eq question.send(attr).as_json
+        end
+      end
+
+      describe 'answers' do
+        let(:answer) { answers.first }
+        let(:answer_response) { question_response['answers'].first }
+
+        it 'returns list of answers' do
+          expect(question_response['answers'].size).to eq 3
+        end
+
+        it 'returns all public fields' do
+          %w[id body author_id created_at updated_at].each do |attr|
+            expect(answer_response[attr]).to eq answer.send(attr).as_json
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/api/v1/questions_spec.rb
+++ b/spec/api/v1/questions_spec.rb
@@ -10,7 +10,7 @@ describe 'Questions API', type: :request do
       let(:method) { :get }
     end
 
-    context 'authorized!' do
+    context 'when authorized!' do
       let(:user) { create(:user) }
       let(:access_token) { create(:access_token) }
       let!(:questions) { create_list(:question, 2) }
@@ -71,7 +71,7 @@ describe 'Questions API', type: :request do
       let(:method) { :get }
     end
 
-    context 'authorized' do
+    context 'when authorized' do
       before do
         get api_path, params: { access_token: access_token.token }, headers: headers
       end
@@ -123,7 +123,7 @@ describe 'Questions API', type: :request do
 
     it_behaves_like 'API Authorizable'
 
-    context 'authorized' do
+    context 'when authorized' do
       let(:access_token) { create(:access_token) }
 
       before do
@@ -146,7 +146,7 @@ describe 'Questions API', type: :request do
         let(:resource)          { Question.last }
       end
 
-      context 'invalid params' do
+      context 'with invalid params' do
         before do
           post api_path,
                params: invalid_params.merge(access_token: access_token.token),
@@ -171,7 +171,7 @@ describe 'Questions API', type: :request do
 
     it_behaves_like 'API Authorizable'
 
-    context 'authorized' do
+    context 'when authorized' do
       let(:access_token) { create(:access_token, resource_owner_id: user.id) }
 
       before do
@@ -196,7 +196,7 @@ describe 'Questions API', type: :request do
         let(:resource)          { question }
       end
 
-      context 'invalid params' do
+      context 'with invalid params' do
         before do
           patch api_path,
                 params: { question: { title: nil } }
@@ -221,7 +221,7 @@ describe 'Questions API', type: :request do
 
     it_behaves_like 'API Authorizable'
 
-    context 'authorized' do
+    context 'when authorized' do
       let(:access_token) { create(:access_token, resource_owner_id: user.id) }
 
       it 'deletes question (200) and returns deleted JSON' do

--- a/spec/factories/access_tokens.rb
+++ b/spec/factories/access_tokens.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :access_token, class: 'Doorkeeper::AccessToken' do
+    association :application, factory: :oauth_application
+    resource_owner_id { create(:user).id }
+    scopes { 'public' }
+  end
+end

--- a/spec/factories/answers.rb
+++ b/spec/factories/answers.rb
@@ -17,5 +17,16 @@ FactoryBot.define do
         ]
       end
     end
+
+    trait :with_file do
+      files do
+        [
+          Rack::Test::UploadedFile.new(
+            Rails.root.join('spec/fixtures/files/example.txt'),
+            'text/plain'
+          )
+        ]
+      end
+    end
   end
 end

--- a/spec/factories/oauth_applications.rb
+++ b/spec/factories/oauth_applications.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :oauth_application, class: 'Doorkeeper::Application' do
+    name { 'Test' }
+    redirect_uri { 'urn:ietf:wg:oauth:2.0:oob' }
+    uid { '12345678' }
+    secret { '87654321' }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,6 +42,7 @@ RSpec.configure do |config|
   config.include ControllerHelpers, type: :controller
   config.include FeatureHelpers, type: :feature
   config.include Warden::Test::Helpers
+  config.include ApiHelpers, type: :request
   config.after { Warden.test_reset! }
 
   # Capybara.javascript_driver = :selenium_chrome_headless

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -1,0 +1,5 @@
+module ApiHelpers
+  def json
+    @json ||= JSON.parse(response.body)
+  end
+end

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -2,4 +2,14 @@ module ApiHelpers
   def json
     @json ||= JSON.parse(response.body)
   end
+
+  def do_request(method, path, params: {}, headers: {})
+    send(
+      method,
+      path,
+      params: params,
+      headers: headers,
+      as: :json
+    )
+  end
 end

--- a/spec/support/features_helpers.rb
+++ b/spec/support/features_helpers.rb
@@ -5,6 +5,8 @@ module FeatureHelpers
     fill_in 'Password', with: user.password
     click_on 'Log in'
 
+    expect(page).to have_current_path(root_path, ignore_query: true)
+
     expect(page).to have_content 'Signed in successfully'
   end
 

--- a/spec/support/shared/api_authorization.rb
+++ b/spec/support/shared/api_authorization.rb
@@ -1,0 +1,32 @@
+shared_examples_for 'API Authorizable' do
+  context 'unauthorized' do
+    it 'returns status: 401 if there is no access_token' do
+      do_request(method, api_path, headers: headers)
+      expect(response.status).to eq 401
+    end
+
+    it 'returns status: 401 if access_token is invalid' do
+      do_request(method, api_path, params: { access_token: '1234' }, headers: headers)
+      expect(response.status).to eq 401
+    end
+  end
+end
+
+shared_examples_for 'Status OK' do
+  it 'returns 200 status' do
+    expect(response).to be_successful
+  end
+end
+
+shared_examples_for 'Return public fields' do
+  it 'returns all public fields' do
+    fields.each do |attr|
+      if %w[created_at updated_at].include?(attr)
+        timestamp = Time.iso8601(resource_response[attr])
+        expect(timestamp).to be_within(1.second).of(resource.send(attr))
+      else
+        expect(resource_response[attr]).to eq resource.send(attr).as_json
+      end
+    end
+  end
+end

--- a/spec/support/shared/api_authorization.rb
+++ b/spec/support/shared/api_authorization.rb
@@ -1,5 +1,5 @@
 shared_examples_for 'API Authorizable' do
-  context 'unauthorized' do
+  context 'when unauthorized' do
     it 'returns status: 401 if there is no access_token' do
       do_request(method, api_path, headers: headers)
       expect(response.status).to eq 401


### PR DESCRIPTION
Реализовать Authorization Code Flow ([github.com](https://github.com/doorkeeper-gem/doorkeeper/wiki/Authorization-Code-Flow)) в своем проекте, используя gem doorkeeper

Важные примечания:
 
Начиная с версии Rails 5.2.4 при указании заголовка  CONTENT_TYPE в тестах запросов, может возникать ошибка парсинга ответа. В этом случае просто удалите этот заголовок из запросов, оставив только заголовок ACCEPT.
При создании приложения через интерфейс Doorkeeper нужно обязательно прописать ему scope (любой), иначе авторизационный токен не будет сгенерирован.

1. Реализовать API с использованием ActiveModelSerializer для:
Профиля пользователя (/api/v1/profiles/me)
Списка профилей всех пользователей, за исключением аутентифицированного
Списка вопросов
Отдельного вопроса (включает в себя список комментариев, список прикрепленных файлов в виде url и список прикрепленных ссылок)
Списка ответов для вопроса
Отдельного ответа (включает в себя список комментариев, список прикрепленных файлов в виде url и список прикрепленных ссылок)
Создания, редактирования и удаления вопроса (без возможности прикреплять файлы)
Создания ответа для вопроса (без возможности прикреплять файлы)
Редактирования и удаления ответа

Внимание! Не забывайте использовать авторизацию (проверку прав через CanCan/Pundit) для API!

Вынести в shared examples:
Тесты для API (общие части) 